### PR TITLE
Fix -fcoroutines driver option and change coroutine_handle name lookup to use std::experimental

### DIFF
--- a/include/clang/Driver/CC1Options.td
+++ b/include/clang/Driver/CC1Options.td
@@ -636,10 +636,6 @@ def fdefault_calling_conv_EQ : Joined<["-"], "fdefault-calling-conv=">,
 def finclude_default_header : Flag<["-"], "finclude-default-header">,
   HelpText<"Include the default header file for OpenCL">;
 
-// C++ TSes.
-def fcoroutines : Flag<["-"], "fcoroutines">,
-  HelpText<"Enable support for the C++ Coroutines TS">;
-
 //===----------------------------------------------------------------------===//
 // Header Search Options
 //===----------------------------------------------------------------------===//

--- a/include/clang/Driver/Options.td
+++ b/include/clang/Driver/Options.td
@@ -481,6 +481,13 @@ def fno_autolink : Flag <["-"], "fno-autolink">, Group<f_Group>,
   Flags<[DriverOption, CC1Option]>,
   HelpText<"Disable generation of linker directives for automatic library linking">;
 
+// C++ Coroutines TS
+def fcoroutines : Flag <["-"], "fcoroutines">, Group<f_Group>,
+  Flags<[DriverOption, CC1Option]>,
+  HelpText<"Enable support for the C++ Coroutines TS">;
+def fno_coroutines : Flag <["-"], "fno-coroutines">, Group<f_Group>,
+  Flags<[DriverOption]>;
+
 def fembed_bitcode_EQ : Joined<["-"], "fembed-bitcode=">,
     Group<f_Group>, Flags<[DriverOption, CC1Option]>, MetaVarName<"<option>">,
     HelpText<"Embed LLVM bitcode (option: off, all, bitcode, marker)">;

--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -717,6 +717,10 @@ public:
   /// \brief The C++ "std" namespace, where the standard library resides.
   LazyDeclPtr StdNamespace;
 
+  /// \brief The C++ "std::experimental" namespace, where the experimental parts
+  /// of the standard library resides.
+  LazyDeclPtr StdExperimentalNamespace;
+
   /// \brief The C++ "std::bad_alloc" class, which is defined by the C++
   /// standard library.
   LazyDeclPtr StdBadAlloc;
@@ -4235,6 +4239,8 @@ public:
 
   NamespaceDecl *getStdNamespace() const;
   NamespaceDecl *getOrCreateStdNamespace();
+
+  NamespaceDecl *getStdExperimentalNamespace() const;
 
   CXXRecordDecl *getStdBadAlloc() const;
 

--- a/lib/Driver/Tools.cpp
+++ b/lib/Driver/Tools.cpp
@@ -5418,6 +5418,11 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       CmdArgs.push_back("-fblocks-runtime-optional");
   }
 
+  if (Args.hasFlag(options::OPT_fcoroutines, options::OPT_fno_coroutines, false)
+      && types::isCXX(InputType)) {
+    CmdArgs.push_back("-fcoroutines");
+  }
+
   // -fmodules enables the use of precompiled modules (off by default).
   // Users can pass -fno-cxx-modules to turn off modules support for
   // C++/Objective-C++ programs.

--- a/lib/Lex/PPMacroExpansion.cpp
+++ b/lib/Lex/PPMacroExpansion.cpp
@@ -1210,6 +1210,7 @@ static bool HasFeature(const Preprocessor &PP, StringRef Feature) {
       // Type traits
       // N.B. Additional type traits should not be added to the following list.
       // Instead, they should be detected by has_extension.
+      .Case("coroutines", LangOpts.Coroutines)
       .Case("has_nothrow_assign", LangOpts.CPlusPlus)
       .Case("has_nothrow_copy", LangOpts.CPlusPlus)
       .Case("has_nothrow_constructor", LangOpts.CPlusPlus)

--- a/lib/Sema/SemaCoroutine.cpp
+++ b/lib/Sema/SemaCoroutine.cpp
@@ -27,7 +27,7 @@ using namespace sema;
 static QualType lookupPromiseType(Sema &S, const FunctionProtoType *FnType,
                                   SourceLocation Loc) {
   // FIXME: Cache std::coroutine_traits once we've found it.
-  NamespaceDecl *Std = S.getStdNamespace();
+  NamespaceDecl *Std = S.getStdExperimentalNamespace();
   if (!Std) {
     S.Diag(Loc, diag::err_implied_std_coroutine_traits_not_found);
     return QualType();
@@ -102,7 +102,7 @@ static QualType lookupPromiseType(Sema &S, const FunctionProtoType *FnType,
 
 static ClassTemplateDecl *lookupStdCoroutineHandle(Sema &S, SourceLocation Loc) {
   // FIXME: Cache std::coroutine_handle once we've found it.
-  NamespaceDecl *Std = S.getStdNamespace();
+  NamespaceDecl *Std = S.getStdExperimentalNamespace();
   if (!Std) {
     S.Diag(Loc, diag::err_implied_std_coroutine_handle_not_found);
     return nullptr;

--- a/lib/Sema/SemaDeclCXX.cpp
+++ b/lib/Sema/SemaDeclCXX.cpp
@@ -8111,7 +8111,9 @@ Decl *Sema::ActOnStartNamespaceDef(Scope *NamespcScope,
   bool IsInline = InlineLoc.isValid();
   bool IsInvalid = false;
   bool IsStd = false;
+  bool IsStdExperimental = false;
   bool AddToKnown = false;
+  DeclContext *ScopeContext = NamespcScope->getEntity();
   Scope *DeclRegionScope = NamespcScope->getParent();
 
   NamespaceDecl *PrevNS = nullptr;
@@ -8152,6 +8154,11 @@ Decl *Sema::ActOnStartNamespaceDef(Scope *NamespcScope,
       PrevNS = getStdNamespace();
       IsStd = true;
       AddToKnown = !IsInline;
+    } else if (II->isStr("experimental") &&
+              CurContext->getRedeclContext()->isStdNamespace()) {
+      PrevNS = getStdExperimentalNamespace();
+      IsStdExperimental = true;
+      AddToKnown = !IsInline;
     } else {
       // We've seen this namespace for the first time.
       AddToKnown = !IsInline;
@@ -8186,6 +8193,8 @@ Decl *Sema::ActOnStartNamespaceDef(Scope *NamespcScope,
 
   if (IsStd)
     StdNamespace = Namespc;
+  if (IsStdExperimental)
+    StdExperimentalNamespace = Namespc;
   if (AddToKnown)
     KnownNamespaces[Namespc] = false;
   
@@ -8269,6 +8278,12 @@ CXXRecordDecl *Sema::getStdBadAlloc() const {
 NamespaceDecl *Sema::getStdNamespace() const {
   return cast_or_null<NamespaceDecl>(
                                  StdNamespace.get(Context.getExternalSource()));
+}
+
+
+NamespaceDecl *Sema::getStdExperimentalNamespace() const {
+  return cast_or_null<NamespaceDecl>(
+                                 StdExperimentalNamespace.get(Context.getExternalSource()));
 }
 
 /// \brief Retrieve the special "std" namespace, which may require us to 

--- a/lib/Sema/SemaDeclCXX.cpp
+++ b/lib/Sema/SemaDeclCXX.cpp
@@ -8113,7 +8113,6 @@ Decl *Sema::ActOnStartNamespaceDef(Scope *NamespcScope,
   bool IsStd = false;
   bool IsStdExperimental = false;
   bool AddToKnown = false;
-  DeclContext *ScopeContext = NamespcScope->getEntity();
   Scope *DeclRegionScope = NamespcScope->getParent();
 
   NamespaceDecl *PrevNS = nullptr;

--- a/lib/Serialization/ASTReaderDecl.cpp
+++ b/lib/Serialization/ASTReaderDecl.cpp
@@ -146,13 +146,13 @@ namespace clang {
 
     /// Results from loading a RedeclarableDecl.
     class RedeclarableResult {
-      GlobalDeclID FirstID;
       Decl *MergeWith;
+      GlobalDeclID FirstID;
       bool IsKeyDecl;
 
     public:
-      RedeclarableResult(GlobalDeclID FirstID, Decl *MergeWith, bool IsKeyDecl)
-          : FirstID(FirstID), MergeWith(MergeWith), IsKeyDecl(IsKeyDecl) {}
+      RedeclarableResult(Decl *MergeWith, GlobalDeclID FirstID, bool IsKeyDecl)
+        : MergeWith(MergeWith), FirstID(FirstID), IsKeyDecl(IsKeyDecl) {}
 
       /// \brief Retrieve the first ID.
       GlobalDeclID getFirstID() const { return FirstID; }
@@ -2311,7 +2311,7 @@ ASTDeclReader::VisitRedeclarable(Redeclarable<T> *D) {
   if (IsFirstLocalDecl)
     Reader.PendingDeclChains.push_back(std::make_pair(DAsT, RedeclOffset));
 
-  return RedeclarableResult(FirstDeclID, MergeWith, IsKeyDecl);
+  return RedeclarableResult(MergeWith, FirstDeclID, IsKeyDecl);
 }
 
 /// \brief Attempts to merge the given declaration (D) with another declaration
@@ -2353,9 +2353,10 @@ void ASTDeclReader::mergeTemplatePattern(RedeclarableTemplateDecl *D,
                                          DeclID DsID, bool IsKeyDecl) {
   auto *DPattern = D->getTemplatedDecl();
   auto *ExistingPattern = Existing->getTemplatedDecl();
-  RedeclarableResult Result(DPattern->getCanonicalDecl()->getGlobalID(),
-                            /*MergeWith*/ ExistingPattern, IsKeyDecl);
-
+  RedeclarableResult Result(/*MergeWith*/ ExistingPattern,  
+                            DPattern->getCanonicalDecl()->getGlobalID(), 
+                            IsKeyDecl);
+  
   if (auto *DClass = dyn_cast<CXXRecordDecl>(DPattern)) {
     // Merge with any existing definition.
     // FIXME: This is duplicated in several places. Refactor.

--- a/test/Coroutines/Inputs/coroutine.h
+++ b/test/Coroutines/Inputs/coroutine.h
@@ -1,6 +1,7 @@
 #pragma once
 
-namespace std {
+namespace std { namespace experimental { inline namespace coroutines_v1 {
+
 template <typename R, typename...> struct coroutine_traits {
   using promise_type = typename R::promise_type;
 };
@@ -75,4 +76,8 @@ struct suspend_never {
   void await_suspend(coroutine_handle<>) {}
   void await_resume() {}
 };
-}
+
+}}}
+
+namespace coro = std::experimental::coroutines_v1;
+

--- a/test/Coroutines/Inputs/generator.h
+++ b/test/Coroutines/Inputs/generator.h
@@ -3,21 +3,21 @@
 template <typename _Ty> struct generator {
   struct promise_type {
     _Ty current_value;
-    std::suspend_always yield_value(_Ty value) {
+    coro::suspend_always yield_value(_Ty value) {
       this->current_value = value;
       return {};
     }
-    std::suspend_always initial_suspend() { return {}; }
-    std::suspend_always final_suspend() { return {}; }
+    coro::suspend_always initial_suspend() { return {}; }
+    coro::suspend_always final_suspend() { return {}; }
     generator get_return_object() { return generator{this}; };
     void return_void() {}
   };
 
   struct iterator {
-    std::coroutine_handle<promise_type> _Coro;
+    coro::coroutine_handle<promise_type> _Coro;
     bool _Done;
 
-    iterator(std::coroutine_handle<promise_type> Coro, bool Done)
+    iterator(coro::coroutine_handle<promise_type> Coro, bool Done)
         : _Coro(Coro), _Done(Done) {}
 
     iterator &operator++() {
@@ -53,7 +53,7 @@ template <typename _Ty> struct generator {
 
 private:
   explicit generator(promise_type *p)
-      : p(std::coroutine_handle<promise_type>::from_promise(*p)) {}
+      : p(coro::coroutine_handle<promise_type>::from_promise(*p)) {}
 
-  std::coroutine_handle<promise_type> p;
+  coro::coroutine_handle<promise_type> p;
 };

--- a/test/Coroutines/brokenIR.cpp
+++ b/test/Coroutines/brokenIR.cpp
@@ -1,14 +1,14 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fcoroutines -emit-llvm %s -o - -std=c++14 -O2 | FileCheck %s
 #include "Inputs/coroutine.h"
 
-struct coro {
+struct coro_t {
   struct promise_type {
-    coro get_return_object() {
-      std::coroutine_handle<promise_type>{};
+    coro_t get_return_object() {
+      coro::coroutine_handle<promise_type>{};
       return {};
     }
-    std::suspend_never initial_suspend() { return {}; }
-    std::suspend_never final_suspend() { return {}; }
+    coro::suspend_never initial_suspend() { return {}; }
+    coro::suspend_never final_suspend() { return {}; }
     void return_void(){}
   };
 };
@@ -29,7 +29,7 @@ struct A {
   template <typename F> void await_suspend(F) {}
 };
 
-extern "C" coro f(int n) {
+extern "C" coro_t f(int n) {
   if (n == 0) {
     print(0);
     co_return;

--- a/test/Coroutines/expected.cpp
+++ b/test/Coroutines/expected.cpp
@@ -38,14 +38,14 @@ struct expected {
   struct promise_type {
     Data data;
     DataPtr get_return_object() { return {&data}; }
-    std::suspend_never initial_suspend() { return {}; }
-    std::suspend_never final_suspend() { return {}; }
+    coro::suspend_never initial_suspend() { return {}; }
+    coro::suspend_never final_suspend() { return {}; }
     void return_value(T v) { data.val = std::move(v); data.error = {};}
   };
 
   bool await_ready() { return !data.error; }
   T await_resume() { return std::move(data.val); }
-  void await_suspend(std::coroutine_handle<promise_type> h) {
+  void await_suspend(coro::coroutine_handle<promise_type> h) {
     h.promise().data.error =std::move(data.error);
     h.destroy();
   }

--- a/test/Coroutines/go.cpp
+++ b/test/Coroutines/go.cpp
@@ -2,9 +2,8 @@
 #define assert(...)
 #define printf(...)
 #include "Inputs/coroutine.h"
-//#include "experimental/coroutine.h"
 
-using namespace std;
+using namespace std::experimental;
 
 bool cancel = false;
 

--- a/test/Coroutines/mini_generator.cpp
+++ b/test/Coroutines/mini_generator.cpp
@@ -4,12 +4,12 @@
 struct minig {
   struct promise_type {
     int current_value;
-    std::suspend_always yield_value(int value) {
+    coro::suspend_always yield_value(int value) {
       this->current_value = value;
       return {};
     }
-    std::suspend_always initial_suspend() { return {}; }
-    std::suspend_always final_suspend() { return {}; }
+    coro::suspend_always initial_suspend() { return {}; }
+    coro::suspend_always final_suspend() { return {}; }
     minig get_return_object() { return minig{this}; };
   };
 
@@ -28,9 +28,9 @@ struct minig {
 
 private:
   explicit minig(promise_type *p)
-      : p(std::coroutine_handle<promise_type>::from_promise(*p)) {}
+      : p(coro::coroutine_handle<promise_type>::from_promise(*p)) {}
 
-  std::coroutine_handle<promise_type> p;
+  coro::coroutine_handle<promise_type> p;
 };
 
 minig fib(int n) { 

--- a/test/Coroutines/multishot_func.cpp
+++ b/test/Coroutines/multishot_func.cpp
@@ -11,10 +11,10 @@ template <typename R> struct func {
     Input* I;
     R result;
     func get_return_object() { return {this}; }
-    std::suspend_always initial_suspend() { return {}; }
-    std::suspend_never final_suspend() { return {}; }
+    coro::suspend_always initial_suspend() { return {}; }
+    coro::suspend_never final_suspend() { return {}; }
     template <typename F>
-    std::suspend_always yield_value(F&& f) { 
+    coro::suspend_always yield_value(F&& f) {
       result = f(I->a, I->b); 
       return {};
     }
@@ -56,8 +56,8 @@ template <typename R> struct func {
 
 private:
   func(promise_type *promise)
-      : h(std::coroutine_handle<promise_type>::from_promise(*promise)) {}
-  std::coroutine_handle<promise_type> h;
+      : h(coro::coroutine_handle<promise_type>::from_promise(*promise)) {}
+  coro::coroutine_handle<promise_type> h;
 };
 
 int Do(int acc, int n, func<int> f) { 

--- a/test/Coroutines/oneshot_func.cpp
+++ b/test/Coroutines/oneshot_func.cpp
@@ -8,8 +8,8 @@ template <typename R> struct func {
   struct promise_type {
     R result;
     func get_return_object() { return {this}; }
-    std::suspend_always initial_suspend() { return {}; }
-    std::suspend_always final_suspend() { return {}; }
+    coro::suspend_always initial_suspend() { return {}; }
+    coro::suspend_always final_suspend() { return {}; }
     void return_value(R v) { result = v; }
   };
 
@@ -46,8 +46,8 @@ template <typename R> struct func {
 
 private:
   func(promise_type *promise)
-      : h(std::coroutine_handle<promise_type>::from_promise(*promise)) {}
-  std::coroutine_handle<promise_type> h;
+      : h(coro::coroutine_handle<promise_type>::from_promise(*promise)) {}
+  coro::coroutine_handle<promise_type> h;
 };
 
 extern "C" int yield(int);

--- a/test/Driver/coroutines.m
+++ b/test/Driver/coroutines.m
@@ -1,0 +1,6 @@
+// RUN: %clang -### %s 2>&1 | FileCheck -check-prefix=CHECK-NO-CORO %s
+// RUN: %clang -fcoroutines -### %s 2>&1 | FileCheck -check-prefix=CHECK-NO-CORO %s
+// RUN: %clang -fno-coroutines -### %s 2>&1 | FileCheck -check-prefix=CHECK-NO-CORO %s
+// RUN: %clang -fno-coroutines -fcoroutines -### %s 2>&1 | FileCheck -check-prefix=CHECK-NO-CORO %s
+// CHECK-NO-CORO-NOT: -fcoroutines
+

--- a/test/Driver/coroutines.mm
+++ b/test/Driver/coroutines.mm
@@ -1,0 +1,9 @@
+// RUN: %clang -### %s 2>&1 | FileCheck -check-prefix=CHECK-NO-CORO %s
+// RUN: %clang -fcoroutines -fno-coroutines -### %s 2>&1 | FileCheck -check-prefix=CHECK-NO-CORO %s
+// RUN: %clang -fno-coroutines -### %s 2>&1 | FileCheck -check-prefix=CHECK-NO-CORO %s
+// CHECK-NO-CORO-NOT: -fcoroutines
+
+// RUN: %clang -fcoroutines -### %s 2>&1 | FileCheck -check-prefix=CHECK-HAS-CORO  %s
+// RUN: %clang -fno-coroutines -fcoroutines -### %s 2>&1 | FileCheck -check-prefix=CHECK-HAS-CORO %s
+// CHECK-HAS-CORO: -fcoroutines
+

--- a/test/Lexer/has_feature_coroutines.m
+++ b/test/Lexer/has_feature_coroutines.m
@@ -1,0 +1,13 @@
+// RUN: %clang_cc1 -E -fcoroutines %s -o - | FileCheck --check-prefix=CHECK-HAS-COROUTINES %s
+// RUN: %clang_cc1 -E %s -o - | FileCheck --check-prefix=CHECK-NO-COROUTINES %s
+// RUN: %clang_cc1 -E -x c -fcoroutines %s -o - | FileCheck --check-prefix=CHECK-HAS-COROUTINES %s
+
+#if __has_feature(coroutines)
+int has_coroutines();
+#else
+int no_coroutines();
+#endif
+
+// CHECK-HAS-COROUTINES: has_coroutines
+// CHECK-NO-COROUTINES: no_coroutines
+


### PR DESCRIPTION
Hi Gor,

Currently the -fcoroutines flag is a CC1 only flag. It really should be both a Driver and CC1 flag. This patch fixes the option and adds tests for the new options.

Note that this branch is ahead of the current coro branch and that's causing unrelated commits to show up in this PR. Please merge ToT clang to fix this.
