### PR TITLE
Fix coroutine.cpp test to use std::experimental

### DIFF
--- a/lib/Sema/SemaCoroutine.cpp
+++ b/lib/Sema/SemaCoroutine.cpp
@@ -405,7 +405,8 @@ ExprResult Sema::BuildCoyieldExpr(SourceLocation Loc, Expr *E) {
   if (!Coroutine)
     return ExprError();
 
-  if (E->getType()->isPlaceholderType()) {
+  if (E->getType()->isPlaceholderType() &&
+      !E->getType()->isSpecificPlaceholderType(BuiltinType::Overload)) {
     ExprResult R = CheckPlaceholderExpr(E);
     if (R.isInvalid()) return ExprError();
     E = R.get();
@@ -419,20 +420,17 @@ ExprResult Sema::BuildCoyieldExpr(SourceLocation Loc, Expr *E) {
 
   // FIXME: Moved it from ActOnCoyieldExpr to BuildCoyieldExpr, otherwise,
   //   mutlishot_func.cpp breaks. There must be a better fix.
-
   // Build yield_value call.
   ExprResult Awaitable =
-    buildPromiseCall(*this, Coroutine, Loc, "yield_value", E);
+      buildPromiseCall(*this, Coroutine, Loc, "yield_value", E);
   if (Awaitable.isInvalid())
     return ExprError();
   E = Awaitable.get();
 
-#if 0 // FIXME: Make it work
   // Build 'operator co_await' call.
-  Awaitable = buildOperatorCoawaitCall(*this, S, Loc, Awaitable.get());
+  Awaitable = buildOperatorCoawaitCall(*this, getCurScope(), Loc, E);
   if (Awaitable.isInvalid())
     return ExprError();
-#endif
 
   // If the expression is a temporary, materialize it as an lvalue so that we
   // can use it multiple times.
@@ -454,6 +452,7 @@ ExprResult Sema::BuildCoyieldExpr(SourceLocation Loc, Expr *E) {
 StmtResult Sema::ActOnCoreturnStmt(SourceLocation Loc, Expr *E) {
   return BuildCoreturnStmt(Loc, E);
 }
+
 StmtResult Sema::BuildCoreturnStmt(SourceLocation Loc, Expr *E) {
   auto *Coroutine = checkCoroutineContext(*this, Loc, "co_return");
   if (!Coroutine)

--- a/test/SemaCXX/coroutines.cpp
+++ b/test/SemaCXX/coroutines.cpp
@@ -22,50 +22,51 @@ void no_coroutine_traits() {
   co_await a; // expected-error {{need to include <coroutine>}}
 }
 
-namespace std {
+namespace std { namespace experimental {
   template<typename ...T> struct coroutine_traits; // expected-note {{declared here}}
-};
+}}
 
 template<typename Promise> struct coro {};
 template<typename Promise, typename... Ps>
-struct std::coroutine_traits<coro<Promise>, Ps...> {
+struct std::experimental::coroutine_traits<coro<Promise>, Ps...> {
   using promise_type = Promise;
 };
 
 void no_specialization() {
-  co_await a; // expected-error {{implicit instantiation of undefined template 'std::coroutine_traits<void>'}}
+  co_await a; // expected-error {{implicit instantiation of undefined template 'std::experimental::coroutine_traits<void>'}}
 }
 
-template<typename ...T> struct std::coroutine_traits<int, T...> {};
+template<typename ...T> struct std::experimental::coroutine_traits<int, T...> {};
 
 int no_promise_type() {
-  co_await a; // expected-error {{this function cannot be a coroutine: 'std::coroutine_traits<int>' has no member named 'promise_type'}}
+  co_await a; // expected-error {{this function cannot be a coroutine: 'std::experimental::coroutine_traits<int>' has no member named 'promise_type'}}
 }
 
-template<> struct std::coroutine_traits<double, double> { typedef int promise_type; };
+template<> struct std::experimental::coroutine_traits<double, double> { typedef int promise_type; };
 double bad_promise_type(double) {
-  co_await a; // expected-error {{this function cannot be a coroutine: 'std::coroutine_traits<double, double>::promise_type' (aka 'int') is not a class}}
+  co_await a; // expected-error {{this function cannot be a coroutine: 'std::experimental::coroutine_traits<double, double>::promise_type' (aka 'int') is not a class}}
 }
 
-template<> struct std::coroutine_traits<double, int> {
+template<> struct std::experimental::coroutine_traits<double, int> {
   struct promise_type {};
 };
 double bad_promise_type_2(int) {
-  co_yield 0; // expected-error {{no member named 'yield_value' in 'std::coroutine_traits<double, int>::promise_type'}}
+  co_yield 0; // expected-error {{no member named 'yield_value' in 'std::experimental::coroutine_traits<double, int>::promise_type'}}
 }
 
 struct promise; // expected-note 2{{forward declaration}}
-template<typename ...T> struct std::coroutine_traits<void, T...> { using promise_type = promise; };
+template<typename ...T> struct std::experimental::coroutine_traits<void, T...> { using promise_type = promise; };
 
-namespace std {
+
+namespace std { namespace experimental {
   template <typename Promise = void> struct coroutine_handle;
-}
+}}
 
-template <> struct std::coroutine_handle<void> {
+template <> struct std::experimental::coroutine_handle<void> {
   static coroutine_handle from_address(void *addr) noexcept;
 };
 template <typename Promise>
-struct std::coroutine_handle : std::coroutine_handle<> {};
+struct std::experimental::coroutine_handle : std::experimental::coroutine_handle<> {};
 
   // FIXME: This diagnostic is terrible.
 void undefined_promise() { // expected-error {{variable has incomplete type 'promise_type'}}
@@ -192,7 +193,7 @@ namespace dependent_operator_co_await_lookup {
 }
 
 struct yield_fn_tag {};
-template<> struct std::coroutine_traits<void, yield_fn_tag> {
+template<> struct std::experimental::coroutine_traits<void, yield_fn_tag> {
   struct promise_type {
     // FIXME: add an await_transform overload for functions
     awaitable yield_value(int());

--- a/test/SemaCXX/coroutines.cpp
+++ b/test/SemaCXX/coroutines.cpp
@@ -83,9 +83,9 @@ struct promise {
   void get_return_object();
   suspend_always initial_suspend();
   suspend_always final_suspend();
-  awaitable yield_value(int); // expected-note 1{{candidate}}
-  awaitable yield_value(yielded_thing); // expected-note 1{{candidate}}
-  not_awaitable yield_value(void()); // expected-note 1{{candidate}}
+  awaitable yield_value(int); // expected-note 2{{candidate}}
+  awaitable yield_value(yielded_thing); // expected-note 2{{candidate}}
+  not_awaitable yield_value(void()); // expected-note 2{{candidate}}
   void return_void();
   void return_value(int); // expected-note 2{{here}}
 };
@@ -212,7 +212,7 @@ namespace placeholder {
     co_await f; // expected-error {{reference to overloaded function}}
   }
   void y() {
-    // co_yield g; FIXME: expected-err0r {{no matching member function for call to 'yield_value'}}
+    co_yield g; // expected-error {{no matching member function for call to 'yield_value'}}
   }
   void z() {
     co_await a;
@@ -223,7 +223,7 @@ namespace placeholder {
     co_await f; // expected-error {{reference to overloaded function}}
   }
   void y(yield_fn_tag) {
-// FIXME:    co_yield g;
+    co_yield g;
   }
   void z(yield_fn_tag) {
     co_await a;


### PR DESCRIPTION
This fixes the coroutine.cpp test I broke when I changed to using std::experimental::coroutine_traits.
